### PR TITLE
Stream embeddings to disk

### DIFF
--- a/narrative_process/embeddings/arg_embeddings.py
+++ b/narrative_process/embeddings/arg_embeddings.py
@@ -1,4 +1,5 @@
 import os
+import pickle
 import numpy as np
 import pandas as pd
 from tqdm import tqdm
@@ -17,27 +18,58 @@ def find_phrase_in_tokens(phrase, sentence_tokens, tokenizer):
             return i, i + len(phrase_tokens)
     return -1, -1
 
-def generate_embeddings(df, bertembeds_module):
-    edicts = []
-    for ind, row in tqdm(df.iterrows(), total=len(df)):
-        s = str(row["sentence"])
-        if len(tokenizer.tokenize(s)) > 500:
-            edicts.append({"fullavg": np.nan})
-            continue
+def generate_embeddings(df, bertembeds_module, output=None):
+    """Generate embeddings for arguments in ``df``.
 
-        tokens, embeds = bertembeds_module.generate_bert_embeddings(s)
-        args = row.dropna().drop(["sentence", "post_id", "description"])
-        embeddict = {}
-        for argkey in args.keys():
-            argphrase = args[argkey]
-            start, end = find_phrase_in_tokens(argphrase, tokens, tokenizer)
-            if ((start != -1) or (end != -1)) and len(range(start, end)) > 0:
-                estack = [embeds[i] for i in range(start, end)]
-                avg = np.mean(estack, axis=0)
-                embeddict[argkey] = avg
-        embeddict["fullavg"] = np.mean(list(embeddict.values()), axis=0) if embeddict else np.nan
-        edicts.append(embeddict)
-    return edicts
+    If ``output`` is provided, each embedding dictionary is pickled to the
+    given file path or file handle as it is computed. When writing to disk the
+    function returns a summary dictionary containing the output path (when
+    applicable) and the number of records written. If ``output`` is ``None`` the
+    list of embedding dictionaries is returned as before.
+    """
+
+    close_handle = False
+    handle = None
+    summary = {"count": 0}
+
+    if output is not None:
+        if isinstance(output, str):
+            handle = open(output, "wb")
+            summary["path"] = output
+            close_handle = True
+        else:
+            handle = output
+            summary["path"] = getattr(output, "name", None)
+
+    edicts = []
+
+    for row in tqdm(df.itertuples(index=False), total=len(df)):
+        row_dict = row._asdict()
+        s = str(row_dict.get("sentence", ""))
+        if len(tokenizer.tokenize(s)) > 500:
+            embeddict = {"fullavg": np.nan}
+        else:
+            tokens, embeds = bertembeds_module.generate_bert_embeddings(s)
+            args = {k: v for k, v in row_dict.items() if k not in ("sentence", "post_id", "description") and pd.notna(v)}
+            embeddict = {}
+            for argkey, argphrase in args.items():
+                start, end = find_phrase_in_tokens(argphrase, tokens, tokenizer)
+                if ((start != -1) or (end != -1)) and len(range(start, end)) > 0:
+                    estack = [embeds[i] for i in range(start, end)]
+                    avg = np.mean(estack, axis=0)
+                    embeddict[argkey] = avg
+            embeddict["fullavg"] = np.mean(list(embeddict.values()), axis=0) if embeddict else np.nan
+
+        if handle is not None:
+            pickle.dump(embeddict, handle)
+            summary["count"] += 1
+        else:
+            edicts.append(embeddict)
+
+    if handle is not None and close_handle:
+        handle.close()
+
+    return summary if handle is not None else edicts
 
 def process(value, df, edf):
     indices_arg0 = df[df['arg0'] == value].index

--- a/narrative_process/main.py
+++ b/narrative_process/main.py
@@ -5,7 +5,7 @@ import pandas as pd
 import numpy as np
 import tempfile
 from tqdm import tqdm
-from narrative_process.utils.io import save_pickle, load_pickle, log_message
+from narrative_process.utils.io import save_pickle, load_pickle, log_message, iter_pickles
 from narrative_process.embeddings import bert, arg_embeddings
 from narrative_process.clustering import cosine_matrix, agglomerative, community
 from narrative_process.srl.srl_spacy_parallel import process_texts_parallel
@@ -91,10 +91,10 @@ def run_pipeline(
         log(f"{len(df)} sentences with non-empty arg0/arg1")
 
         # === Argument Embeddings ===
-        edicts = arg_embeddings.generate_embeddings(df, bert)
+        summary = arg_embeddings.generate_embeddings(df, bert, output=embeddings_path)
+        edicts = list(iter_pickles(embeddings_path))
         edf = pd.DataFrame(edicts)
-        save_pickle(edicts, embeddings_path)
-        log(f"Generated embeddings for {len(edf)} records")
+        log(f"Generated embeddings for {summary['count']}")
 
         # === Averaged Argument Embeddings ===
         concatenated_args = df[['arg0', 'arg1']].values.ravel('K')

--- a/narrative_process/utils/io.py
+++ b/narrative_process/utils/io.py
@@ -11,6 +11,24 @@ def load_pickle(path):
     with open(path, "rb") as f:
         return pickle.load(f)
 
+def iter_pickles(path_or_file):
+    """Yield objects sequentially from a pickle file containing multiple dumps."""
+    close_handle = False
+    if isinstance(path_or_file, str):
+        f = open(path_or_file, "rb")
+        close_handle = True
+    else:
+        f = path_or_file
+    try:
+        while True:
+            try:
+                yield pickle.load(f)
+            except EOFError:
+                break
+    finally:
+        if close_handle:
+            f.close()
+
 def log_message(message, logfile=None):
     timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
     full_msg = f"{timestamp} - {message}"


### PR DESCRIPTION
## Summary
- support writing embedding dictionaries incrementally
- load them back with helper `iter_pickles`
- update main pipeline to use streaming embeddings

## Testing
- `python -m compileall -q narrative_process/embeddings/arg_embeddings.py narrative_process/main.py narrative_process/utils/io.py`

------
https://chatgpt.com/codex/tasks/task_e_687e8b485d1483269b1340cb952241c3