### PR TITLE
Add README and CSV import example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# Narrative Process
+
+This repository contains a Python pipeline for extracting and clustering narrative relations from text.
+
+## How it works
+
+1. **Semantic Role Labeling (SRL)** – Uses a custom spaCy component to identify verbs and their arguments (ARG0, ARG1, etc.) in each sentence.
+2. **Embedding generation** – Computes BERT embeddings for the arguments with `transformers` and `torch`.
+3. **Clustering** – Groups similar arguments and relations using cosine similarity, agglomerative clustering and Louvain community detection (`scikit-learn`, `networkx`, `python-louvain`).
+4. **Roll‑up and output** – Aggregates clustered relations and produces summary tables that show the most central terms.
+
+## Usage
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Prepare a CSV file with a column named `text` containing sentences.
+3. Run the pipeline:
+   ```bash
+   python scripts/run_pipeline_example.py
+   ```
+   This script reads an example CSV and processes it through the pipeline.
+
+## Simple CSV import example
+
+A minimal example that simply loads a CSV and prints its first rows is provided:
+
+```bash
+python scripts/import_csv_example.py
+```
+
+This demonstrates how to load a CSV using pandas and is a starting point for integrating your own data.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,10 @@
-# Required Python packages
+pandas
+numpy
+tqdm
+scikit-learn
+networkx
+python-louvain
+spacy
+joblib
+torch
+transformers

--- a/scripts/import_csv_example.py
+++ b/scripts/import_csv_example.py
@@ -1,0 +1,12 @@
+import os
+import pandas as pd
+
+
+def main():
+    csv_path = os.path.join(os.path.dirname(__file__), "incels test.csv")
+    df = pd.read_csv(csv_path)
+    print(df.head())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Document narrative processing pipeline and usage in new README
- Specify project dependencies in requirements.txt
- Provide a simple example script demonstrating CSV loading with pandas

## Testing
- `python scripts/import_csv_example.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba02b4970c8326b0ff9e2926e3e9c3