### PR TITLE
feat: add narrative pipeline CSV example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,8 @@ This repository contains a Python pipeline for extracting and clustering narrati
    pip install -r requirements.txt
    ```
 2. Prepare a CSV file with a column named `text` containing sentences.
-3. Run the pipeline:
+3. Run the pipeline on the included example CSV:
    ```bash
-   python scripts/run_pipeline_example.py
+   python scripts/import_csv_example.py
    ```
-   This script reads an example CSV and processes it through the pipeline.
-
-## Simple CSV import example
-
-A minimal example that simply loads a CSV and prints its first rows is provided:
-
-```bash
-python scripts/import_csv_example.py
-```
-
-This demonstrates how to load a CSV using pandas and is a starting point for integrating your own data.
+   This script loads a sample dataset and processes it through the narrative pipeline, printing the first few relation rows.

--- a/scripts/import_csv_example.py
+++ b/scripts/import_csv_example.py
@@ -1,11 +1,28 @@
 import os
 import pandas as pd
 
+from narrative_process.main import run_pipeline
+
 
 def main():
-    csv_path = os.path.join(os.path.dirname(__file__), "incels test.csv")
+    """Run the narrative process pipeline on an example CSV."""
+
+    scripts_dir = os.path.dirname(__file__)
+    csv_path = os.path.join(scripts_dir, "incels test.csv")
+
+    # Load example data. The CSV must contain a column named ``text``.
     df = pd.read_csv(csv_path)
-    print(df.head())
+
+    # Run the pipeline and capture the resulting relation dataframe
+    results = run_pipeline(
+        df[["text"]],
+        working_dir=os.path.join(scripts_dir, "temp_output"),
+        verbose=False,
+    )
+
+    rels = results["rels"]
+    print("Top relation rows:")
+    print(rels.head())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- show how to run the narrative pipeline on the included example CSV
- document the new example script in the README

## Testing
- `pip install -r requirements.txt` *(fails: Operation cancelled by user)*
- `python scripts/import_csv_example.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68ba06ef68108326afe7aee0d279c258